### PR TITLE
feature/ELACITY-556: Royalties distrubution input

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "dependencies": {
-    "@elacity-js/lib": "^0.1.18",
+    "@elacity-js/lib": "^0.2.0",
     "@elacity-js/uikit": "^1.6.0-alpha.9",
     "@elastosfoundation/did-js-sdk": "^2.2.9",
     "@elastosfoundation/elastos-connectivity-sdk-js": "^1.1.4",

--- a/src/App.css
+++ b/src/App.css
@@ -107,10 +107,6 @@ iframe {
 	        animation: shake-horizontal 0.8s cubic-bezier(0.455, 0.030, 0.515, 0.955) both;
 }
 
-.MainLayout {
-  padding-top: 40px !important;
-}
-
 @media only screen and (max-width: 600px) {
   .css-mtaedb {
     display: none;

--- a/src/hooks/useMediaLoader.ts
+++ b/src/hooks/useMediaLoader.ts
@@ -1,10 +1,10 @@
 import {
   useMemo, useState, useEffect,
 } from 'react';
-import { CollectionOf } from '@elacity-js/lib';
+import { CollectionOf, INTERFACE_ERC721 } from '@elacity-js/lib';
 import { useWeb3React } from '@web3-react/core';
 import { BigNumberish } from '@ethersproject/bignumber';
-import mediaTokenArtifact from '../lib/scm/deployer/iface/MediaToken.json';
+// import mediaTokenArtifact from '../lib/scm/deployer/iface/MediaToken.json';
 import { Erc721ContractType } from '../lib/web3/contract';
 import { useAddresses } from '../lib/web3/hooks';
 import { MediaTokenAsset } from '../types';
@@ -19,7 +19,7 @@ class MediaToken extends Erc721ContractType<MediaTokenAsset> {
 }
 
 const mediaFormatter = async (item: MediaTokenAsset) => {
-  const rs = await fetch(item.tokenURI);
+  const rs = await fetch(`https://ipfs.ela.city/ipfs/${item.tokenURI}`);
   const metadata = await rs.json();
 
   return {
@@ -34,7 +34,7 @@ const mediaFormatter = async (item: MediaTokenAsset) => {
 
 export default (method: string, args: BigNumberish[]) => {
   const { chainId, library } = useWeb3React();
-  const { MEDIA_TOKEN } = useAddresses();
+  const { TEMP721 } = useAddresses();
   const [result, setResult] = useState<CollectionOf<MediaTokenAsset>>({
     total: 0,
     items: [],
@@ -45,12 +45,12 @@ export default (method: string, args: BigNumberish[]) => {
   const contract = useMemo(() => {
     const abiMap = {
       [chainId]: {
-        abi: mediaTokenArtifact.abi,
-        address: MEDIA_TOKEN,
+        abi: INTERFACE_ERC721,
+        address: TEMP721,
       },
     };
 
-    if (!MEDIA_TOKEN || !chainId || !library?.provider) {
+    if (!TEMP721 || !chainId || !library?.provider) {
       return null;
     }
 

--- a/src/lib/typeform/components/Blocks.tsx
+++ b/src/lib/typeform/components/Blocks.tsx
@@ -88,7 +88,7 @@ const Blocks = ({ stepIndex }: BlocksProps) => {
           error={errors[selectBlock.input?.fieldName]}
           button={selectBlock.button}
         >
-          <SelectChoice {...selectBlock as SelectChoiceBlock} />
+          <SelectChoice {...{ input: selectBlock.input } as SelectChoiceBlock} />
         </Question>
       );
       break;

--- a/src/lib/typeform/components/Blocks.tsx
+++ b/src/lib/typeform/components/Blocks.tsx
@@ -1,7 +1,8 @@
+/* eslint-disable no-redeclare */
 /* eslint-disable no-case-declarations */
 /* eslint-disable max-len */
 import React from 'react';
-import { get } from 'lodash';
+import { get, merge } from 'lodash';
 import classNames from 'classnames';
 import { useFormikContext } from 'formik';
 import Grid from '@mui/material/Grid';
@@ -10,6 +11,7 @@ import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import { Theme, useMediaQuery } from '@mui/material';
 import useFormUI from '../hooks/useFormUI';
+import useBlockHelpers from '../hooks/useBlockHelpers';
 import {
   QuestionInputProps,
   Block,
@@ -45,6 +47,7 @@ const Blocks = ({ stepIndex }: BlocksProps) => {
   const { values, errors } = useFormikContext();
   const { currentStep /* onPrevious, onNext */ } = useFormUI();
   const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
+  const { injectInputProps, injectUploaderProps } = useBlockHelpers();
 
   // Swipe action listener
   // @TODO: not yet sure if it works as expected, need to check
@@ -70,49 +73,53 @@ const Blocks = ({ stepIndex }: BlocksProps) => {
       break;
     case 'select-card':
       const scBlock = content as SelectCardBlock;
+      const { error: scError, ...scProps } = injectInputProps(scBlock.input?.fieldName);
       section = (
         <Question
           {...(scBlock.input as QuestionInputProps)}
-          error={errors[scBlock.input?.fieldName]}
+          error={scError}
           button={scBlock.button}
         >
-          <CardSelect {...scBlock as SelectCardBlock} />
+          <CardSelect {...merge(scBlock, { input: scProps }) as SelectCardBlock} />
         </Question>
       );
       break;
     case 'select-choice':
       const selectBlock = content as SelectChoiceBlock;
+      const { error: selectError, ...selectProps } = injectInputProps(selectBlock.input?.fieldName);
       section = (
         <Question
           {...(selectBlock.input as QuestionInputProps)}
-          error={errors[selectBlock.input?.fieldName]}
+          error={selectError}
           button={selectBlock.button}
         >
-          <SelectChoice {...{ input: selectBlock.input } as SelectChoiceBlock} />
+          <SelectChoice {...({ input: selectBlock.input, ...selectProps }) as unknown as SelectChoiceBlock} />
         </Question>
       );
       break;
     case 'text':
       const textBlock = content as TextInputBlock;
+      const { error: textError, ...textProps } = injectInputProps(textBlock.input?.fieldName);
       section = (
         <Question
           {...(textBlock.input as QuestionInputProps)}
-          error={errors[textBlock.input?.fieldName]}
+          error={textError}
           button={textBlock.button}
         >
-          <TextInput {...textBlock as TextInputBlock} />
+          <TextInput {...merge(textBlock, { input: textProps }) as TextInputBlock} />
         </Question>
       );
       break;
     case 'uploader':
       const uploaderBlock = content as UploaderBlock;
+      const { error: uploaderError, ...uploaderProps } = injectUploaderProps(uploaderBlock.input?.fieldName);
       section = (
         <Question
           {...(uploaderBlock.input as QuestionInputProps)}
-          error={errors[uploaderBlock.input?.fieldName]}
+          error={uploaderError}
           button={uploaderBlock.button}
         >
-          <Uploader {...uploaderBlock as UploaderBlock} />
+          <Uploader {...merge(uploaderBlock, { input: uploaderProps }) as UploaderBlock} />
         </Question>
       );
       break;

--- a/src/lib/typeform/components/Title.tsx
+++ b/src/lib/typeform/components/Title.tsx
@@ -14,7 +14,7 @@ const TypoTitle = styled(Typography)<TypographyProps & {component?: string}>(({ 
   '& .flag-required': {
     color: theme.palette.error.main,
     fontWeight: 500,
-    marginLeft: theme.spacing(0.5),
+    marginLeft: theme.spacing(0),
   },
 }));
 

--- a/src/lib/typeform/components/fields/SelectChoice.tsx
+++ b/src/lib/typeform/components/fields/SelectChoice.tsx
@@ -81,7 +81,7 @@ export const Option = ({ KeyPressId, value, isSelected, onSelect }: OptionProps)
   </CardStyled>
 );
 
-interface SelectProps extends SelectChoiceBlock {}
+interface SelectProps extends Omit<SelectChoiceBlock, 'button' | 'type'> {}
 
 const SelectChoice = ({ input }: SelectProps) => {
   const { ref, onSelect, isSelected } = useSelectFn(input);

--- a/src/lib/typeform/components/fields/TextInput.tsx
+++ b/src/lib/typeform/components/fields/TextInput.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import Input from '@mui/material/Input';
+import useAutofocus from 'src/lib/typeform/hooks/useAutofocus';
 import { TextInputBlock } from '../../types';
 
-export default ({ input: { helpText, ...input } }: TextInputBlock) => (
-  <Box
-    component="div"
-    sx={{
-      '& > :not(style)': { m: 1 },
-    }}
-  >
-    <Input {...input} />
-  </Box>
-);
+export default ({ input: { helpText, fieldName, ...input } }: TextInputBlock) => {
+  const inputRef = useAutofocus();
+  return (
+    <Box
+      component="div"
+      sx={{
+        '& > :not(style)': { m: 1 },
+      }}
+    >
+      <Input {...input} inputRef={inputRef} />
+    </Box>
+  );
+};

--- a/src/lib/typeform/components/fields/Uploader.tsx
+++ b/src/lib/typeform/components/fields/Uploader.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Box } from '@mui/material';
 import { Uploader, InlineUploaderProps } from '@elacity-js/uikit';
 import { UploaderBlock } from '../../types';
 
@@ -8,14 +9,16 @@ export interface UploaderCardProps extends InlineUploaderProps {
 }
 
 const UploaderCard = ({ input: { indicator, title, caption, maxSize, ...props } }: UploaderBlock) => (
-  <Uploader.Inline
-    maxSize={maxSize || 2 * 1024 * 1024 * 1024}
-    supportedFileDescription=".MP4, .MPEG are supported, up to 2Gb"
-    accept={{
-      'video/*': ['.mp4', '.mpeg'],
-    }}
-    {...props}
-  />
+  <Box sx={{ mb: 2, maxHeight: '80vh' }}>
+    <Uploader.Inline
+      maxSize={maxSize || 2 * 1024 * 1024 * 1024}
+      supportedFileDescription=".MP4, .MPEG are supported, up to 2Gb"
+      accept={{
+        'video/*': ['.mp4', '.mpeg'],
+      }}
+      {...props}
+    />
+  </Box>
 );
 
 export default UploaderCard;

--- a/src/lib/typeform/components/static/RoyaltySetup/InnerStepper.tsx
+++ b/src/lib/typeform/components/static/RoyaltySetup/InnerStepper.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import ButtonGroup from '@mui/material/ButtonGroup';
+import Button from '@mui/material/Button';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import SubdirectoryArrowRightIcon from '@mui/icons-material/SubdirectoryArrowRight';
+
+interface InnerStepProps {
+  onPrev: () => void;
+  onNext: () => void;
+  onComplete: () => void;
+  isFirst?: boolean;
+  isLast?: boolean;
+}
+
+export default ({ onPrev, onNext, onComplete, isFirst, isLast }: InnerStepProps) => (
+  <ButtonGroup
+    disableElevation
+    variant="contained"
+    size="large"
+    sx={{
+      '&.MuiButtonGroup-root': {
+        '& .MuiButtonBase-root': {
+          mr: 0.1,
+          borderRight: 'none',
+          borderLeft: 'none',
+        },
+      },
+    }}
+  >
+    <Button disabled={isFirst} onClick={onPrev} startIcon={<ArrowBackIcon />}>Prev</Button>
+    {!isLast ? (
+      <Button disabled={isLast} onClick={onNext} endIcon={<ArrowForwardIcon />}>Next</Button>
+    ) : (
+      <Button onClick={onComplete} endIcon={<SubdirectoryArrowRightIcon />}>Continue</Button>
+    )}
+  </ButtonGroup>
+);

--- a/src/lib/typeform/components/static/RoyaltySetup/PartyDetail.tsx
+++ b/src/lib/typeform/components/static/RoyaltySetup/PartyDetail.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Box, OutlinedInput } from '@mui/material';
+import InputLabel from '@mui/material/InputLabel';
+import InputAdornment from '@mui/material/InputAdornment';
+import FormControl from '@mui/material/FormControl';
+import { RoyaltySet } from 'src/lib/typeform/types';
+import useAutofocus from 'src/lib/typeform/hooks/useAutofocus';
+
+// declare type State = Omit<RoyaltySet, 'indentifier'>;
+declare type State = RoyaltySet;
+
+interface PartyDetailProps {
+  partyKey: string;
+  values: Record<string, State>;
+  onChange?: (partyKey: string, prop: keyof State) => (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default ({ partyKey, values, onChange }: PartyDetailProps) => {
+  const inputRef = useAutofocus();
+
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', '& .MuiFormControl-root': { ml: 0 } }}>
+      <FormControl fullWidth sx={{ m: 1 }}>
+        <InputLabel>Address</InputLabel>
+        <OutlinedInput
+          inputRef={inputRef}
+          label="Address"
+          value={values[partyKey]?.address}
+          onChange={onChange?.(partyKey, 'address')}
+        />
+      </FormControl>
+      <FormControl sx={{ m: 1, width: '10ch' }}>
+        <InputLabel>Value</InputLabel>
+        <OutlinedInput
+          type="number"
+          label="Value"
+          value={values[partyKey]?.royalty}
+          onChange={onChange?.(partyKey, 'royalty')}
+          endAdornment={<InputAdornment position="end">%</InputAdornment>}
+          inputProps={{
+            'aria-label': 'weight',
+            max: 100,
+          }}
+        />
+      </FormControl>
+    </Box>
+  );
+};

--- a/src/lib/typeform/components/static/RoyaltySetup/RoyaltySetup.tsx
+++ b/src/lib/typeform/components/static/RoyaltySetup/RoyaltySetup.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import classNames from 'classnames';
 import { useFormikContext } from 'formik';
-import { Box, Button } from '@mui/material';
+import {
+  Box, Button, Typography,
+} from '@mui/material';
 import Slide from '@mui/material/Slide';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import {
@@ -52,7 +54,12 @@ const RoyaltySetup = ({ options, fieldName }: RoyaltySetupProps) => {
             <>
               Enter address and royalty ratio for
               {' '}
-              <span style={{ fontWeight: 500 }}>{royalties[parties[innerStep - 2]]?.identifier}</span>
+              <Typography
+                component="span"
+                sx={{ fontWeight: 500, color: 'primary.dark' }}
+              >
+                {royalties[parties[innerStep - 2]]?.identifier}
+              </Typography>
             </>
           )
         }
@@ -87,6 +94,11 @@ const RoyaltySetup = ({ options, fieldName }: RoyaltySetupProps) => {
                 onClick={handleNext}
               >
                 Setup
+                {
+                  parties.length > 0 && (
+                    ` (${parties.length})`
+                  )
+                }
               </Button>
             </>
           ) : (

--- a/src/lib/typeform/components/static/RoyaltySetup/RoyaltySetup.tsx
+++ b/src/lib/typeform/components/static/RoyaltySetup/RoyaltySetup.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import classNames from 'classnames';
+import { useFormikContext } from 'formik';
+import { Box, Button } from '@mui/material';
+import Slide from '@mui/material/Slide';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import {
+  RoyaltySet, MintForm, SelectOptions,
+} from 'src/lib/typeform/types';
+import Question from '../../Question';
+import SelectChoice from '../../fields/SelectChoice';
+import useFormUI from '../../../hooks/useFormUI';
+import PartyDetail from './PartyDetail';
+import InnerStepper from './InnerStepper';
+import { useRoyaltiesSetup } from './handlers';
+
+interface RoyaltySetupProps {
+  fieldName: keyof MintForm;
+  options: SelectOptions[];
+}
+
+const RoyaltySetup = ({ options, fieldName }: RoyaltySetupProps) => {
+  const { errors, values, setFieldValue } = useFormikContext<MintForm>();
+  const { onNext } = useFormUI();
+
+  const {
+    handleComplete,
+    handleRoyaltyChange,
+    handleNext,
+    handlePrev,
+    handleSelectChange,
+    innerStep,
+    parties,
+    royalties,
+  } = useRoyaltiesSetup({
+    values: values.royalties || [],
+    options,
+    onComplete: (val: RoyaltySet[]) => {
+      // don't validate right now, will be validated only `onNext` execution
+      setFieldValue(fieldName, val, false);
+      setTimeout(onNext, 500, { forceValidation: true });
+    },
+  });
+
+  return (
+    <Box className={classNames({ 'shake-horizontal': Boolean(errors[fieldName]) })}>
+      <Question
+        title="Who do you need to distribute royalties to?"
+        indicator={5}
+        caption={
+          innerStep > 1 && (
+            <>
+              Enter address and royalty ratio for
+              {' '}
+              <span style={{ fontWeight: 500 }}>{royalties[parties[innerStep - 2]]?.identifier}</span>
+            </>
+          )
+        }
+        fieldName={fieldName}
+        button={null}
+        error={
+          Boolean(errors[fieldName]) && (
+            errors[fieldName] as string
+          )
+        }
+      >
+        {
+          innerStep === 1 ? (
+            <>
+              <SelectChoice
+                input={{
+                  multiple: true,
+                  placeholder: 'Choose as many as you like',
+                  title: '',
+                  fieldName,
+                  value: parties,
+                  onChange: handleSelectChange,
+                  options,
+                }}
+              />
+              <Button
+                disableElevation
+                size="large"
+                variant="contained"
+                sx={{ boxShadow: 0, my: 2 }}
+                endIcon={<ArrowForwardIcon />}
+                onClick={handleNext}
+              >
+                Setup
+              </Button>
+            </>
+          ) : (
+            <Box mt={1}>
+              <Slide direction="right" in mountOnEnter unmountOnExit>
+                <Box>
+                  <PartyDetail
+                    partyKey={parties[innerStep - 2]}
+                    values={royalties}
+                    onChange={handleRoyaltyChange}
+                  />
+                </Box>
+              </Slide>
+              <Box sx={{ my: 2 }}>
+                <InnerStepper
+                  onPrev={handlePrev}
+                  onNext={handleNext}
+                  isLast={innerStep === parties.length + 1}
+                  onComplete={handleComplete}
+                />
+              </Box>
+            </Box>
+          )
+        }
+      </Question>
+    </Box>
+  );
+};
+
+export default RoyaltySetup;

--- a/src/lib/typeform/components/static/RoyaltySetup/handlers.ts
+++ b/src/lib/typeform/components/static/RoyaltySetup/handlers.ts
@@ -1,0 +1,89 @@
+import React from 'react';
+import { RoyaltySet } from 'src/lib/typeform/types';
+
+interface PartyOption {
+  KeyPressId: string;
+  value: string;
+}
+
+interface Params {
+  options: PartyOption[];
+  values: RoyaltySet[];
+  onComplete: (roylaties: RoyaltySet[], parties?: string[]) => void;
+}
+
+export const useRoyaltiesSetup = ({ options, values, onComplete }: Params) => {
+  const [innerStep, setInnerStep] = React.useState<number>(1);
+  const [parties, setParties] = React.useState<string[]>((values || []).map(({ key }) => key));
+  const [royalties, setRoyalties] = React.useState<Record<string, RoyaltySet>>(
+    Object.fromEntries((values || []).map(({ key, ...t }) => [key, { key, ...t }]))
+  );
+
+  const handleComplete = React.useCallback(
+    () => {
+      onComplete(Object.entries(royalties).map(
+        ([partyKey, royalty]) => ({
+          ...royalty,
+          key: partyKey,
+        })
+      ), parties);
+    }, [royalties, parties]
+  );
+
+  React.useEffect(() => {
+    setRoyalties(
+      (prev: Record<string, RoyaltySet>) => parties.reduce(
+        (result: Record<string, RoyaltySet>, partyKey: string) => ({
+          ...result,
+          [partyKey]: prev[partyKey] || {
+            identifier: options.find((o) => o.KeyPressId === partyKey)?.value,
+            address: '',
+            royalty: 0,
+          },
+        }), {}
+      )
+    );
+  }, [parties]);
+
+  const handleRoyaltyChange = (partyKey: string, prop: keyof RoyaltySet) => (
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setRoyalties(
+        (prev: Record<string, RoyaltySet>) => ({
+          ...prev,
+          [partyKey]: {
+            ...prev[partyKey],
+            [prop]: e.target.value,
+          },
+        })
+      );
+    }
+  );
+
+  const handleSelectChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    // @ts-ignore
+    setParties(e.target.value);
+  }, []);
+
+  const handleNext = React.useCallback(() => {
+    setInnerStep(
+      (prev) => prev + 1
+    );
+  }, [parties]);
+
+  const handlePrev = React.useCallback(() => {
+    setInnerStep(
+      (prev) => prev - 1
+    );
+  }, [parties]);
+
+  return {
+    handleSelectChange,
+    handleRoyaltyChange,
+    handleComplete,
+    handleNext,
+    handlePrev,
+    innerStep,
+    parties,
+    royalties,
+  };
+};

--- a/src/lib/typeform/components/static/RoyaltySetup/index.ts
+++ b/src/lib/typeform/components/static/RoyaltySetup/index.ts
@@ -1,0 +1,3 @@
+import RoyaltySetup from './RoyaltySetup';
+
+export default RoyaltySetup;

--- a/src/lib/typeform/contexts/FormUIContext.tsx
+++ b/src/lib/typeform/contexts/FormUIContext.tsx
@@ -1,20 +1,53 @@
+/* eslint-disable no-fallthrough */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable max-len */
 import { useFormikContext } from 'formik';
 import { TransitionProps } from '@mui/material/transitions';
 import React, {
-  FC, PropsWithChildren, createContext, useState, KeyboardEvent,
+  FC, PropsWithChildren, createContext, useState, KeyboardEvent, useCallback,
 } from 'react';
 import {
   Block, FormStep, MintForm,
 } from '../types/index';
+
+/**
+ * This helper will handle how all the steps will flow
+ * according to actual step and values from the form
+ *
+ * @returns
+ */
+const useStepFlow = () => {
+  const { values } = useFormikContext<MintForm>();
+
+  const stepForward = useCallback((stepId: number) => {
+    console.log({ stepId, values });
+    if (stepId === 4 && values.accessMethod === 'A') {
+      return 7;
+    }
+
+    return stepId + 1;
+  }, [values]);
+
+  const stepBackward = useCallback((stepId: number) => {
+    if (stepId === 7 && values.accessMethod === 'A') {
+      return 4;
+    }
+
+    return stepId - 1;
+  }, [values]);
+
+  return {
+    stepForward,
+    stepBackward,
+  };
+};
 
 interface OnNextParams {
   forceValidation?: boolean;
 }
 
 interface FormUIContextValue {
-  currentStep: FormStep;
+  currentStep: FormStep<MintForm>;
   onNext: (p?: OnNextParams) => void;
   onPrevious: () => void;
 }
@@ -39,6 +72,7 @@ interface FormUIContextProps {
  */
 export const FormUIProvider: FC<PropsWithChildren<FormUIContextProps>> = ({ children, steps, onFinal, onStep }) => {
   const form = useFormikContext<MintForm>();
+  const { stepForward, stepBackward } = useStepFlow();
   const [currentStep, setCurrentStep] = useState<FormStep>(steps[0]);
 
   // Override step transaction direction on click on the bottom controller up or down
@@ -70,7 +104,7 @@ export const FormUIProvider: FC<PropsWithChildren<FormUIContextProps>> = ({ chil
     console.log('Exec onNext', o);
     if (!o?.forceValidation && currentStep?.id) {
       // go through wth any restriction about validation state
-      _setCurrentStep(currentStep?.id + 1, 'up');
+      _setCurrentStep(stepForward(currentStep?.id), 'up');
       return;
     }
 
@@ -81,7 +115,7 @@ export const FormUIProvider: FC<PropsWithChildren<FormUIContextProps>> = ({ chil
             console.error('Validator Error', errors);
           } else if (currentStep?.id) {
             // next step will show from the bottom -> top
-            _setCurrentStep(currentStep?.id + 1, 'up');
+            _setCurrentStep(stepForward(currentStep?.id), 'up');
           }
         }
       );
@@ -92,14 +126,14 @@ export const FormUIProvider: FC<PropsWithChildren<FormUIContextProps>> = ({ chil
       console.error('Validator Error', form.errors);
     } else if (currentStep?.id) {
       // next step will show from the bottom -> top
-      _setCurrentStep(currentStep?.id + 1, 'up');
+      _setCurrentStep(stepForward(currentStep?.id), 'up');
     }
   }, [currentStep?.id, form.values]);
 
   const onPrevious = () => {
     if (currentStep?.id) {
       // next step will show from the top -> bottom
-      _setCurrentStep(currentStep?.id - 1, 'down');
+      _setCurrentStep(stepBackward(currentStep?.id), 'down');
     }
   };
 
@@ -132,7 +166,6 @@ export const FormUIProvider: FC<PropsWithChildren<FormUIContextProps>> = ({ chil
     <FormUIContext.Provider
       value={{
         currentStep,
-        // setCurrentStep: _setCurrentStep,
         onNext,
         onPrevious,
       }}

--- a/src/lib/typeform/contexts/FormUIContext.tsx
+++ b/src/lib/typeform/contexts/FormUIContext.tsx
@@ -75,7 +75,7 @@ export const FormUIProvider: FC<PropsWithChildren<FormUIContextProps>> = ({ chil
     }
 
     if (o?.forceValidation) {
-      form.validateForm(form.values).then(
+      form.validateForm().then(
         (errors) => {
           if (Object.entries(errors).length > 0) {
             console.error('Validator Error', errors);

--- a/src/lib/typeform/hooks/useAutofocus.ts
+++ b/src/lib/typeform/hooks/useAutofocus.ts
@@ -1,0 +1,13 @@
+import { useRef, useEffect } from 'react';
+
+export default () => {
+  const ref = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.focus();
+    }
+  }, []);
+
+  return ref;
+};

--- a/src/lib/typeform/hooks/useBlockHelpers.ts
+++ b/src/lib/typeform/hooks/useBlockHelpers.ts
@@ -1,0 +1,31 @@
+import { ChangeEvent, useCallback } from 'react';
+import { FileRejection } from 'react-dropzone';
+import { useFormikContext } from 'formik';
+
+export default <T extends unknown>() => {
+  const { values, errors, setFieldValue, setFieldError } = useFormikContext<T>();
+
+  // inject form-related props for input component
+  const injectInputProps = useCallback((fieldName: string) => ({
+    value: values[fieldName],
+    onChange: (
+      e: ChangeEvent<HTMLInputElement>
+    ) => setFieldValue(fieldName, e.target.value),
+    error: errors[fieldName],
+  }), [values, errors]);
+
+  // inject form-related props for uploader component
+  const injectUploaderProps = useCallback((fieldName: string) => ({
+    initialValue: values[fieldName] || null,
+    onDropped: (value: File) => setFieldValue(fieldName, value),
+    onRejected: (rejection: FileRejection[]) => {
+      setFieldError(fieldName, rejection.map((r) => r.errors[0].message).join(', '));
+    },
+    error: errors[fieldName],
+  }), [values, errors]);
+
+  return {
+    injectInputProps,
+    injectUploaderProps,
+  };
+};

--- a/src/lib/typeform/index.tsx
+++ b/src/lib/typeform/index.tsx
@@ -7,10 +7,15 @@ import { FormUIProvider } from './contexts/FormUIContext';
 import questionSteps from './questions';
 import { MintForm } from './types';
 
-const Typeform = () => {
+interface Props {
+  handle?: (values: MintForm) => Promise<{path: string}[]>
+}
+
+const Typeform = ({ handle }: Props) => {
   const [activeStepIndex, setStepIndex] = React.useState<number>(0);
-  const onSubmit = (values: MintForm) => {
-    console.log({ values });
+  const onSubmit = async (values: MintForm) => {
+    console.log('submitting', { values });
+    await handle(values);
   };
 
   const formValidator = React.useCallback((values: MintForm) => {
@@ -120,7 +125,7 @@ const Typeform = () => {
               onFinal={async () => {
                 form.setSubmitting(true);
                 await form.submitForm();
-                setTimeout(form.setSubmitting, 2000, false);
+                setTimeout(form.setSubmitting, 700, false);
               }}
             >
               <Form stepIndex={activeStepIndex} />

--- a/src/lib/typeform/index.tsx
+++ b/src/lib/typeform/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { sumBy } from 'lodash';
 import { Formik, FormikErrors } from 'formik';
 import { ThemeProvider } from './theme';
 import Form from './components/Form';
@@ -38,12 +39,27 @@ const Typeform = () => {
       },
       () => {
         if (!values.pricePerSale && values.accessMethod !== 'A') {
-          errors.pricePerSale = 'The price is required unless you set it as free content';
+          errors.pricePerSale = 'The price is required unless you set the asset as a free content';
         }
       },
       () => {
-        if (!values.parties?.length && values.accessMethod !== 'A') {
-          errors.parties = 'Please choose at least one of the options above';
+        if (values.accessMethod !== 'A') {
+          let royaltiesHasErr = false;
+          values.royalties.forEach((rset) => {
+            if (rset.address === '') {
+              royaltiesHasErr = true;
+            }
+          });
+          if (royaltiesHasErr) {
+            errors.royalties = 'Please fill in all beneficiaries address';
+          } else {
+            const totalPercentage = sumBy(values.royalties, ((r) => Number(r.royalty)));
+            if (totalPercentage !== 100) {
+              console.log({ totalPercentage });
+              // eslint-disable-next-line max-len
+              errors.royalties = `Please make sure total of all percentage is equal to 100%, actual value is ${totalPercentage}%`;
+            }
+          }
         }
       },
       () => {
@@ -87,7 +103,10 @@ const Typeform = () => {
   return (
     <ThemeProvider>
       <Formik
-        initialValues={{}}
+        initialValues={{
+          parties: [],
+          royalties: [],
+        }}
         onSubmit={onSubmit}
         validate={formValidator}
       >

--- a/src/lib/typeform/index.tsx
+++ b/src/lib/typeform/index.tsx
@@ -113,7 +113,7 @@ const Typeform = () => {
         {
           (form) => (
             <FormUIProvider
-              steps={questionSteps(form)}
+              steps={questionSteps}
               onStep={(stepIndex: number) => {
                 setStepIndex(stepIndex);
               }}

--- a/src/lib/typeform/questions.tsx
+++ b/src/lib/typeform/questions.tsx
@@ -563,7 +563,7 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
             value: values.copiesNumber,
             onChange: (
               e: React.ChangeEvent<HTMLInputElement>
-            ) => setFieldValue('copiesNumber', parseInt(e.target.value, 10)),
+            ) => setFieldValue('copiesNumber', e.target.value !== '' ? parseInt(e.target.value, 10) : null),
             error: errors.copiesNumber,
           },
           button: {

--- a/src/lib/typeform/questions.tsx
+++ b/src/lib/typeform/questions.tsx
@@ -25,6 +25,7 @@ import PaidOutlinedIcon from '@mui/icons-material/PaidOutlined';
 import AccessTimeOutlinedIcon from '@mui/icons-material/AccessTimeOutlined';
 
 import Title from 'src/lib/typeform/components/Title';
+import RoyaltySetup from 'src/lib/typeform/components/static/RoyaltySetup';
 import { images } from 'src/lib/typeform/constants';
 import { FormStep, MintForm } from './types';
 import { Img, CenterBox } from './components/Img';
@@ -321,43 +322,69 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
         animation: {
           type: 'slide',
         },
+        // content: {
+        //   type: 'select-choice',
+        //   input: {
+        //     indicator: 5,
+        //     required: true,
+        //     multiple: true,
+        //     placeholder: 'Choose as many as you like',
+        //     title: 'Who do you need to distribute royalties to?',
+        //     options: [
+        //       {
+        //         KeyPressId: 'A',
+        //         value: 'Creator',
+        //       },
+        //       {
+        //         KeyPressId: 'B',
+        //         value: 'Publisher',
+        //       },
+        //       {
+        //         KeyPressId: 'C',
+        //         value: 'Distributor',
+        //       },
+        //       {
+        //         KeyPressId: 'D',
+        //         value: 'Investor',
+        //       },
+        //     ],
+        //     fieldName: 'parties',
+        //     value: values.parties,
+        //     onChange: (e: React.ChangeEvent<HTMLInputElement>) => setFieldValue('parties', e.target.value),
+        //     error: errors.parties,
+        //   },
+        //   button: {
+        //     text: 'OK',
+        //     props: {
+        //       endIcon: <CheckIcon />,
+        //     },
+        //   },
+        // },
         content: {
-          type: 'select-choice',
-          input: {
-            indicator: 5,
-            required: true,
-            multiple: true,
-            placeholder: 'Choose as many as you like',
-            title: 'Who do you need to distribute royalties to?',
-            options: [
-              {
-                KeyPressId: 'A',
-                value: 'Creator',
-              },
-              {
-                KeyPressId: 'B',
-                value: 'Publisher',
-              },
-              {
-                KeyPressId: 'C',
-                value: 'Distributor',
-              },
-              {
-                KeyPressId: 'D',
-                value: 'Investor',
-              },
-            ],
-            fieldName: 'parties',
-            value: values.parties,
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setFieldValue('parties', e.target.value),
-            error: errors.parties,
-          },
-          button: {
-            text: 'OK',
-            props: {
-              endIcon: <CheckIcon />,
-            },
-          },
+          type: 'static',
+          input: (
+            <RoyaltySetup
+              fieldName="royalties"
+              options={[
+                {
+                  KeyPressId: 'A',
+                  value: 'Creator',
+                },
+                {
+                  KeyPressId: 'B',
+                  value: 'Publisher',
+                },
+                {
+                  KeyPressId: 'C',
+                  value: 'Distributor',
+                },
+                {
+                  KeyPressId: 'D',
+                  value: 'Investor',
+                },
+              ]}
+            />
+          ),
         },
       }],
   },

--- a/src/lib/typeform/questions.tsx
+++ b/src/lib/typeform/questions.tsx
@@ -1,9 +1,6 @@
 /* eslint-disable max-len */
 import React from 'react';
-import { FormikProps } from 'formik';
-import { FileRejection } from 'react-dropzone';
 import { Theme, alpha } from '@mui/material/styles';
-import CircularProgress from '@mui/material/CircularProgress';
 import InputAdornment from '@mui/material/InputAdornment';
 import FormatQuoteIcon from '@mui/icons-material/FormatQuote';
 import CheckIcon from '@mui/icons-material/Check';
@@ -30,8 +27,7 @@ import { images } from 'src/lib/typeform/constants';
 import { FormStep, MintForm } from './types';
 import { Img, CenterBox } from './components/Img';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
-export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: FormikProps<MintForm>) => [
+export default [
   {
     id: 1,
     isFirstStep: true,
@@ -108,9 +104,6 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
               },
             ],
             fieldName: 'operator',
-            value: values.operator,
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setFieldValue('operator', e.target.value),
-            error: errors.operator,
           },
           button: {
             text: 'OK',
@@ -163,9 +156,6 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
               },
             ],
             fieldName: 'contentType',
-            value: values.contentType,
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setFieldValue('contentType', e.target.value),
-            error: errors.contentType,
           },
           button: {
             text: 'OK',
@@ -239,9 +229,6 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
               },
             ],
             fieldName: 'accessMethod',
-            value: values.accessMethod,
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setFieldValue('accessMethod', e.target.value),
-            error: errors.accessMethod,
           },
           button: {
             text: 'OK',
@@ -288,11 +275,6 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
               <InputAdornment position="start" sx={{ '& .MuiTypography-root': { fontSize: 26 } }}>ELA</InputAdornment>
             ),
             fieldName: 'pricePerSale',
-            value: values.pricePerSale,
-            onChange: (
-              e: React.ChangeEvent<HTMLInputElement>
-            ) => setFieldValue('pricePerSale', e.target.value),
-            error: errors.pricePerSale,
           },
           button: {
             text: 'OK',
@@ -322,44 +304,6 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
         animation: {
           type: 'slide',
         },
-        // content: {
-        //   type: 'select-choice',
-        //   input: {
-        //     indicator: 5,
-        //     required: true,
-        //     multiple: true,
-        //     placeholder: 'Choose as many as you like',
-        //     title: 'Who do you need to distribute royalties to?',
-        //     options: [
-        //       {
-        //         KeyPressId: 'A',
-        //         value: 'Creator',
-        //       },
-        //       {
-        //         KeyPressId: 'B',
-        //         value: 'Publisher',
-        //       },
-        //       {
-        //         KeyPressId: 'C',
-        //         value: 'Distributor',
-        //       },
-        //       {
-        //         KeyPressId: 'D',
-        //         value: 'Investor',
-        //       },
-        //     ],
-        //     fieldName: 'parties',
-        //     value: values.parties,
-        //     onChange: (e: React.ChangeEvent<HTMLInputElement>) => setFieldValue('parties', e.target.value),
-        //     error: errors.parties,
-        //   },
-        //   button: {
-        //     text: 'OK',
-        //     props: {
-        //       endIcon: <CheckIcon />,
-        //     },
-        //   },
-        // },
         content: {
           type: 'static',
           input: (
@@ -415,12 +359,6 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
               bgcolor: (t: Theme) => alpha(t.palette.primary.light, 0.1),
             },
             fieldName: 'assetFile',
-            initialValue: values.assetFile || null,
-            onDropped: (value: File) => setFieldValue('assetFile', value),
-            onRejected: (rejection: FileRejection[]) => {
-              setErrors({ assetFile: rejection.map((r) => r.errors[0].message).join(', ') });
-            },
-            error: errors.assetFile,
           },
           button: {
             text: 'Continue',
@@ -461,12 +399,6 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
               bgcolor: (t: Theme) => alpha(t.palette.primary.light, 0.1),
             },
             fieldName: 'assetThumbnail',
-            initialValue: values.assetThumbnail || null,
-            onDropped: (value: File) => setFieldValue('assetThumbnail', value),
-            onRejected: (rejection: FileRejection[]) => {
-              setErrors({ assetThumbnail: rejection.map((r) => r.errors[0].message).join(', ') });
-            },
-            error: errors.assetThumbnail,
           },
           button: {
             text: 'Continue',
@@ -499,9 +431,6 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
               },
             },
             fieldName: 'title',
-            value: values.title,
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setFieldValue('title', e.target.value),
-            error: errors.title,
           },
           button: {
             text: 'OK',
@@ -539,9 +468,6 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
               },
             },
             fieldName: 'description',
-            value: values.description,
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) => setFieldValue('description', e.target.value),
-            error: errors.description,
           },
           button: {
             text: 'OK',
@@ -587,11 +513,6 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
               },
             },
             fieldName: 'copiesNumber',
-            value: values.copiesNumber,
-            onChange: (
-              e: React.ChangeEvent<HTMLInputElement>
-            ) => setFieldValue('copiesNumber', e.target.value !== '' ? parseInt(e.target.value, 10) : null),
-            error: errors.copiesNumber,
           },
           button: {
             text: 'OK',
@@ -639,13 +560,9 @@ export default ({ values, errors, setFieldValue, setErrors, isSubmitting }: Form
             props: {
               type: 'submit',
               endIcon: <CheckIcon />,
-              ...(isSubmitting && {
-                disabled: true,
-                startIcon: <CircularProgress sx={{ fontSize: '1rem' }} />,
-              }),
             },
           },
         },
       }],
   },
-] as FormStep[];
+] as FormStep<MintForm>[];

--- a/src/lib/typeform/types/index.ts
+++ b/src/lib/typeform/types/index.ts
@@ -73,12 +73,13 @@ export interface Block {
   animation?: Animation;
 }
 
-export interface FormStep {
+export interface FormStep<T = unknown> {
   id: number;
   blocks: Block[];
   isFirstStep?: boolean;
   isLastStep?: boolean;
   animation?: Animation;
+  stepForward?: (values: T) => FormStep<T>['id'];
 }
 
 export type FormBlock = StaticBlock | TextInputBlock | SelectCardBlock | UploaderBlock | SelectChoiceBlock;

--- a/src/lib/typeform/types/index.ts
+++ b/src/lib/typeform/types/index.ts
@@ -41,7 +41,7 @@ export interface TextInputBlock extends InputForm {
 export interface SelectOptions {
   KeyPressId: string;
   value: string;
-  icon: SvgIconComponent;
+  icon?: SvgIconComponent;
 }
 
 export interface SelectForm extends InputForm {
@@ -83,13 +83,24 @@ export interface FormStep {
 
 export type FormBlock = StaticBlock | TextInputBlock | SelectCardBlock | UploaderBlock | SelectChoiceBlock;
 
+export interface RoyaltySet {
+  key?: string;
+  identifier: string;
+  address?: string;
+  royalty?: number;
+}
+
 export interface MintForm {
   // mint form data
   operator?: string; // Independant creator | Content Creator Group | Content Distributor
   contentType?: string; // Image | Video | Music | 3D Model | Document
   accessMethod?: string; // q3: Free | Buy once...
   pricePerSale?: number;
+
+  // @deprecated soon, use .royalties
   parties?: string[];
+  royalties?: RoyaltySet[];
+
   title?: string;
   description?: string;
   assetFile?: File;

--- a/src/lib/web3/ConnectorContext.tsx
+++ b/src/lib/web3/ConnectorContext.tsx
@@ -256,7 +256,7 @@ export function SelectDialog(props: SelectDialogProps) {
             .reverse()
             .map((c: INetworkConfig) => {
               const matchWithEnv =
-                c.chainID === (process.env.REACT_APP_CHAIN_ID ? parseInt(process.env.REACT_APP_CHAIN_ID, 10) : 3);
+                c.chainID === (process.env.REACT_APP_CHAIN_ID ? parseInt(process.env.REACT_APP_CHAIN_ID, 10) : 21);
               return (
                 <ListItem
                   button

--- a/src/lib/web3/connectors.ts
+++ b/src/lib/web3/connectors.ts
@@ -29,19 +29,16 @@ export const NETWORKS: INetworkCollection = {
     name: 'Elastos Smart Chain',
     symbol: 'ELA',
     chainID: 20,
-    // rpcUrl: 'https://escrpc.elaphant.app',
-    // rpcUrl: 'https://api.elastos.io/eth',
     rpcUrl: 'https://api.trinity-tech.io/esc',
     explorerUrl: 'https://eth.elastos.io',
     decimals: 18,
   },
-  3: {
-    name: 'Ropsten Test Network',
-    symbol: 'ETH',
-    chainID: 3,
-    // rpcUrl: `https://ropsten.infura.io/v3/${INFURA_ID}`,
-    rpcUrl: 'https://ropsten.infura.io/v3/44a8e00e1b7d41889719cc14a97df9ca',
-    explorerUrl: 'https://ropsten.etherscan.io',
+  21: {
+    name: 'ESC Testnet',
+    symbol: 'ELA',
+    chainID: 21,
+    rpcUrl: 'https://api-testnet.trinity-tech.io/esc',
+    explorerUrl: 'https://esc-testnet.elastos.io',
     decimals: 18,
   },
 };
@@ -55,32 +52,27 @@ export const getNetworkForChain = (chainId: number): INetworkConfig | null => {
 };
 
 const RPC_URLS: { [chainId: number]: string } = {
-  3: `https://ropsten.infura.io/v3/${INFURA_ID}`,
-  // 20: 'https://escrpc.elaphant.app',
-  // 20: 'https://api.elastos.io/eth',
-  // 20: 'http://34.142.19.27:20638',
   20: 'https://api.trinity-tech.io/esc',
   21: 'https://rpc.elaeth.io',
 };
 
 export const network = new NetworkConnector({
-  urls: { 3: RPC_URLS[3], 20: RPC_URLS[20] },
+  urls: { 20: RPC_URLS[20], 21: RPC_URLS[21] },
   defaultChainId: 1,
 });
 
 // Metamask needs this
 export const injected = new InjectedConnector({
-  supportedChainIds: [3, 20],
+  supportedChainIds: [20, 21],
 });
 
 // Wallet Connect
 export const walletconnect = new WalletConnectConnector({
-  supportedChainIds: [3, 20],
-  rpc: { 3: RPC_URLS[3], 20: RPC_URLS[20] },
+  supportedChainIds: [20, 21],
+  rpc: { 20: RPC_URLS[20], 21: RPC_URLS[21] },
   // bridge: 'https://c.bridge.walletconnect.org',
   bridge: 'https://walletconnect.elastos.net/v2',
   qrcode: true,
-  infuraId: INFURA_ID,
   qrcodeModalOptions: {
     mobileLinks: [
       'metamask',
@@ -94,9 +86,8 @@ export const walletconnect = new WalletConnectConnector({
 
 // Elastos DID connector, essentials@wallectconnect
 export const essentialConnect = new Web3WalletconnectConnector({
-  supportedChainIds: [3, 20],
-  rpc: { 3: RPC_URLS[3], 20: RPC_URLS[20] },
-  // bridge: 'https://c.bridge.walletconnect.org',
+  supportedChainIds: [20, 21],
+  rpc: { 20: RPC_URLS[20], 21: RPC_URLS[21] },
   bridge: 'https://walletconnect.elastos.net/v2',
   qrcode: true,
   infuraId: INFURA_ID,

--- a/src/lib/web3/hooks.tsx
+++ b/src/lib/web3/hooks.tsx
@@ -131,6 +131,9 @@ export const useAddresses = () => {
   const { chainId } = useWeb3React();
 
   return {
+    TEMP721: chainId === 20
+      ? process.env.REACT_APP_TOKEN721_MAINNET
+      : process.env.REACT_APP_TOKEN721_TESTNET,
     ISSUER_TOKEN: chainId === 20
       ? process.env.REACT_APP_ISSUER_TOKEN_MAINNET
       : process.env.REACT_APP_ISSUER_TOKEN_TESTNET,

--- a/src/views/TypeformView/handler.ts
+++ b/src/views/TypeformView/handler.ts
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import { Contract } from '@ethersproject/contracts';
+import { INTERFACE_ERC721 } from '@elacity-js/lib';
+import { useWeb3React } from '@web3-react/core';
+import useErrorHandler from 'src/hooks/useErrorHandler';
+import { IUploader, IFormTransformer } from '../../lib/uploader';
+import { useAddresses } from '../../lib/web3';
+import { MintForm as BaseType } from '../../lib/typeform/types';
+
+declare type MintForm = BaseType & {author?: string}
+
+interface HandlerParams {
+  uploader: IUploader;
+}
+
+export enum HandlerStatus {
+  INITED = 'Initialization',
+  DEPLOY = 'Contract Deployment',
+  UP_THUMBNAIL = 'Thumbnail Upload',
+  UP_MEDIA = 'Media Upload',
+  SUCCEED = 'succeed',
+  FAILED = 'failed',
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
+const toBase64 = (file: File): Promise<string | ArrayBuffer> => new Promise((resolve, reject) => {
+  const reader = new FileReader();
+  reader.readAsDataURL(file);
+  reader.onload = () => {
+    resolve(reader.result);
+  };
+  reader.onerror = (err) => {
+    reject(err);
+  };
+});
+
+const thumbnailTransformer: IFormTransformer<Pick<MintForm, 'assetThumbnail' | 'title'>> = {
+  transform: async (payload: MintForm) => {
+    const formData = new FormData();
+    formData.append('image', payload.assetThumbnail);
+    formData.append('title', payload.title);
+    return formData;
+  },
+};
+
+const mediaTransformer: IFormTransformer<Omit<MintForm, 'assetThumbnail'> & {thumbnail: string;}> = {
+  transform: async (payload: Omit<MintForm, 'assetThumbnail'> & {thumbnail: string;}) => {
+    const formData = new FormData();
+    formData.append('image', payload.assetFile);
+    formData.append('thumbnailHash', payload.thumbnail);
+    formData.append('title', payload.title);
+    formData.append('description', payload.description);
+    formData.append('author', payload.author);
+    formData.append('price', payload.pricePerSale.toString());
+    formData.append('payToken', '0x0');
+    return formData;
+  },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const jsonTramsformer: IFormTransformer<any> = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transform: async (payload: any) => {
+    const formData = new FormData();
+    const bytes = new TextEncoder().encode(
+      typeof payload === 'string'
+        ? payload
+        : JSON.stringify(payload)
+    );
+    formData.append('data', new Blob([bytes], { type: 'application/json' }));
+    return formData;
+  },
+};
+
+export default ({ uploader }: HandlerParams) => {
+  const { library, account, chainId } = useWeb3React();
+  const { throwError } = useErrorHandler();
+  const { TEMP721 } = useAddresses();
+  const [status, setStatus] = useState<HandlerStatus>(null);
+  const [outcome, setOutcome] = useState<string>(null);
+
+  const handlePayload = async ({ assetThumbnail, title, ...payload }: MintForm) => {
+    setStatus(HandlerStatus.INITED);
+    try {
+      // 1. upload thumbnail -> replace .thumnail with returned CID of the file
+      const thumnailFormData = await thumbnailTransformer.transform({ assetThumbnail, title });
+      setStatus(HandlerStatus.UP_THUMBNAIL);
+      const response1 = await uploader.upload<{path: string}[]>(thumnailFormData, {
+        headers: {
+          'X-Target-Flow': 'ipfs',
+        },
+      });
+
+      // 2. upload media file
+      setStatus(HandlerStatus.UP_MEDIA);
+      const mediaFormData = await mediaTransformer.transform({
+        ...payload,
+        title,
+        thumbnail: response1[0].path,
+      });
+      const response2 = await uploader.upload<{path: string}[]>(mediaFormData, {
+        headers: {
+          'X-Target-Flow': 'dash,ipfs',
+        },
+      });
+
+      // Mint the media as an NFT on MediaToken contract
+      const response3 = await uploader.upload<{path: string}[]>(await jsonTramsformer.transform(JSON.stringify({
+        name: title,
+        description: payload.description,
+        image: response1[0].path,
+        attributes: [
+          { trait_type: 'Thumbnail', value: response1[0].path },
+          { trait_type: 'Media', value: response2[0].path },
+          { trait_type: 'ChainId', value: chainId },
+          { trait_type: 'Author', value: account },
+          { trait_type: 'Distribution', value: payload.accessMethod },
+          { trait_type: 'Royalties', value: payload.royalties },
+          { trait_type: 'LabelType', value: payload.operator },
+        ],
+      })), {
+        headers: {
+          'X-Target-Flow': 'ipfs',
+        },
+      });
+
+      const contract = new Contract(TEMP721, INTERFACE_ERC721, library?.getSigner());
+      const tx = await contract.mint(account, response3[0].path);
+
+      const receipt = await tx.wait();
+
+      console.log({ response1, response2, response3, receipt });
+
+      setStatus(HandlerStatus.SUCCEED);
+      setOutcome(response2[0].path);
+
+      return response2;
+    } catch (e) {
+      throwError(e);
+      setStatus(HandlerStatus.FAILED);
+      return Promise.reject(e);
+    }
+  };
+
+  return {
+    status,
+    handlePayload,
+    outcome,
+  };
+};

--- a/src/views/TypeformView/index.tsx
+++ b/src/views/TypeformView/index.tsx
@@ -3,18 +3,26 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Box } from '@mui/material';
 import Typeform from 'src/lib/typeform';
+import { ClassicUploader } from 'src/lib/uploader';
+import useHandler from './handler';
 
 /**
  * Specify all steps used by the form
  * fully customizable
  */
-const TypeformView = () => (
-  <Box sx={{ height: 'calc(100vh - 136px)' }}>
-    <Helmet>
-      <title>Submission Form | Elacity Media</title>
-    </Helmet>
-    <Typeform />
-  </Box>
-);
+const TypeformView = () => {
+  const { handlePayload } = useHandler({
+    uploader: new ClassicUploader(process.env.REACT_APP_BACKEND_URL),
+  });
+
+  return (
+    <Box sx={{ height: 'calc(100vh - 136px)' }}>
+      <Helmet>
+        <title>Submission Form | Elacity Media</title>
+      </Helmet>
+      <Typeform handle={handlePayload} />
+    </Box>
+  );
+};
 
 export default TypeformView;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,10 +1112,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@elacity-js/lib@^0.1.18":
-  version "0.1.18"
-  resolved "https://registry.yarnpkg.com/@elacity-js/lib/-/lib-0.1.18.tgz#d249d51ccbe5f8533ae8a6ecd5165a017fc67445"
-  integrity sha512-malc4A0U621VcUYe4ggS/gSH6WI0kdU0PEsTDOY5EH2njpwo3UvIEB2BpCWgMotQlF/02XSfyfp25KBD2JTbQg==
+"@elacity-js/lib@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@elacity-js/lib/-/lib-0.2.0.tgz#d66745a5bad2103be3ef26d13f33efa41f2e4ffe"
+  integrity sha512-pSLc7jPYLcfGeegxf0ni4tmh9OLNWosNvllb/zlk9LrddA8Fu44Pflm/CsO7mWluGnIQHy5ORI8wa9LL8dhC0w==
   dependencies:
     "@ethersproject/bignumber" "^5.6.2"
 


### PR DESCRIPTION
- handled royalties distibution with a separated input component as a static in `Blocks` perspective
- located at `src/lib/typeform/components/static/RoyaltySetup`
- separated UI from UX
- formik: put `.parties` as deprecated and used `.royalties` instead